### PR TITLE
Admin dashboard data api

### DIFF
--- a/insurance-ams/package-lock.json
+++ b/insurance-ams/package-lock.json
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"

--- a/insurance-ams/src/Component/ClientPipelineChart.tsx
+++ b/insurance-ams/src/Component/ClientPipelineChart.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { clientPiplineData } from "@/actions/dashboard.action";
 import Image from "next/image";
+import { useEffect, useState } from "react";
 import {
   LineChart,
   Line,
@@ -59,6 +61,31 @@ const data = [
   },
 ];
 
+const piplineChartCount = () => {
+  interface PiplineData {
+    name: string;
+    income: number;
+    fill: string;
+  }
+
+  const [piplineData, setPiplineData] = useState<PiplineData[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const piplineData = await clientPiplineData();
+      setPiplineData(
+        piplineData.map((pipline: any) => ({
+          name: pipline.name,
+          income: pipline.income,
+          fill: pipline.fill,
+        }))
+      );
+    };
+
+    fetchData();
+  });
+};
+
 // Sets the value label on each section
 const CustomLabel: React.FC<LabelProps> = ({ x, y, width, height, value }) => {
   const cx =
@@ -82,6 +109,29 @@ const CustomLabel: React.FC<LabelProps> = ({ x, y, width, height, value }) => {
 };
 
 const ClientPipelineChart = () => {
+  interface PiplineData {
+    name: string;
+    income: number;
+    fill: string;
+  }
+
+  const [piplineData, setPiplineData] = useState<PiplineData[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const piplineData = await clientPiplineData();
+      setPiplineData(
+        piplineData.map((pipline: any) => ({
+          name: pipline.name,
+          income: pipline.income,
+          fill: pipline.fill,
+        }))
+      );
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <div className="bg-white rounded-xl w-full h-full p-4">
       <div className="flex justify-between items-center">
@@ -91,14 +141,18 @@ const ClientPipelineChart = () => {
       <ResponsiveContainer width="100%" height="90%">
         <FunnelChart>
           <Tooltip />
-          <Funnel dataKey="income" data={data} isAnimationActive>
+          <Funnel dataKey="income" data={piplineData} isAnimationActive>
             <LabelList
               position="right"
               fill="#000"
               stroke="none"
               dataKey="name"
             />
-            <LabelList content={<CustomLabel />} dataKey="income" />
+            <LabelList
+              // content={<CustomLabel />}
+              dataKey="income"
+              position="inside"
+            />
           </Funnel>
         </FunnelChart>
       </ResponsiveContainer>

--- a/insurance-ams/src/Component/CountChart.tsx
+++ b/insurance-ams/src/Component/CountChart.tsx
@@ -52,6 +52,8 @@ const countChart = () => {
   const [activePolicies, setActivePolicies] = useState<number>(0);
   const [nonActivePolicies, setNonActivePolicies] = useState<number>(0);
 
+  // calculate percentage of active and non-active policies instead of hardcoding
+
   useEffect(() => {
     const fetchData = async () => {
       const policiesData = await getActivePolicyData();

--- a/insurance-ams/src/Component/CountChart.tsx
+++ b/insurance-ams/src/Component/CountChart.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import React, { useEffect, useState } from "react";
+
+import { getActivePolicyData } from "@/actions/dashboard.action";
 
 import {
   RadialBarChart,
@@ -39,6 +42,39 @@ const style = {
 };
 
 const countChart = () => {
+  interface PolicyData {
+    name: string;
+    total: number;
+    fill: string;
+  }
+
+  const [policiesData, setPoliciesData] = useState<PolicyData[]>([]);
+  const [activePolicies, setActivePolicies] = useState<number>(0);
+  const [nonActivePolicies, setNonActivePolicies] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const policiesData = await getActivePolicyData();
+      console.log("PoliciesData**: ");
+      console.log(policiesData);
+      setPoliciesData(
+        policiesData.map((policy: any) => ({
+          name: policy.name,
+          total: policy.total,
+          fill: policy.fill,
+        }))
+      );
+
+      setActivePolicies(policiesData[0].total);
+      setNonActivePolicies(policiesData[1].total);
+    };
+
+    fetchData();
+
+    console.log("PoliciesData: ");
+    console.log(policiesData);
+  }, []);
+
   return (
     <div className="bg-white rounded-xl w-full h-full p-4">
       {/* Title */}
@@ -55,13 +91,13 @@ const countChart = () => {
             innerRadius="40%"
             outerRadius="100%"
             barSize={30}
-            data={data}
+            data={policiesData}
             endAngle={360}
           >
             <RadialBar
               label={{ position: "insideStart", fill: "#fff" }}
               background
-              dataKey="uv"
+              dataKey="total"
             />
           </RadialBarChart>
         </ResponsiveContainer>
@@ -70,14 +106,28 @@ const countChart = () => {
       <div className="flex justify-center gap-16">
         <div className="flex flex-col gap-1">
           <div className="w-5 h-5 bg-lightCyan rounded-full" />
-          <h1 className="font-bold">200</h1>
-          <h2 className="text-xs text-gray-500">Personal (61.54%)</h2>
+          <h1 className="font-bold">{activePolicies}</h1>
+          <h2 className="text-xs text-gray-500">
+            Active{" ("}
+            {(
+              (activePolicies / (activePolicies + nonActivePolicies)) *
+              100
+            ).toFixed(2)}
+            {"%)"}
+          </h2>
         </div>
 
         <div className="flex flex-col gap-1">
           <div className="w-5 h-5 bg-accentBlue rounded-full" />
-          <h1 className="font-bold">125</h1>
-          <h2 className="text-xs text-gray-500">Commercial (48.46%)</h2>
+          <h1 className="font-bold">{nonActivePolicies}</h1>
+          <h2 className="text-xs text-gray-500">
+            Non-Active{" ("}
+            {(
+              (nonActivePolicies / (activePolicies + nonActivePolicies)) *
+              100
+            ).toFixed(2)}
+            {"%)"}
+          </h2>
         </div>
       </div>
     </div>

--- a/insurance-ams/src/actions/dashboard.action.ts
+++ b/insurance-ams/src/actions/dashboard.action.ts
@@ -130,3 +130,57 @@ export async function getActivePolicyData() {
 
   return data;
 }
+
+export async function getClientAtLeadStage() {
+  const consults = await prisma.client.findMany({
+    where: {
+      stage: Stage.CONSULT,
+    },
+  });
+
+  //   console.log("Client at Lead Stage Data: ");
+  //   console.log(data);
+
+  return consults;
+}
+
+export async function clientPiplineData() {
+  const leads = await getLeads();
+  const consults = await getClientAtLeadStage();
+  const quotes = await getQuotesInProgress();
+  const denied = await getOpenClaims();
+  const accepted = await getPendingToBindPolicies();
+
+  const data = [
+    {
+      name: "Lead",
+      income: leads.length,
+      fill: "#8884d8",
+    },
+    {
+      name: "Consult",
+      income: consults.length,
+      fill: "#83a6ed",
+    },
+    {
+      name: "Quote",
+      income: quotes.length,
+      fill: "#8dd1e1",
+    },
+    {
+      name: "Denied",
+      income: denied.length,
+      fill: "#82ca9d",
+    },
+    {
+      name: "Accepted",
+      income: accepted.length,
+      fill: "#4DB8A4",
+    },
+  ];
+
+  //   console.log("Client Pipeline Data: ");
+  //   console.log(data);
+
+  return data;
+}

--- a/insurance-ams/src/actions/dashboard.action.ts
+++ b/insurance-ams/src/actions/dashboard.action.ts
@@ -93,6 +93,7 @@ export async function getClaims() {
 export async function getPolicies() {
   const policies = await prisma.policy.findMany();
   console.log(`There are ${policies.length} policies.`);
+
   return policies;
 }
 
@@ -124,8 +125,8 @@ export async function getActivePolicyData() {
     },
   ];
 
-  console.log("Active Policy Data: ");
-  console.log(data);
+  //   console.log("Active Policy Data: ");
+  //   console.log(data);
 
   return data;
 }

--- a/insurance-ams/src/app/(dashboard)/admin/page.tsx
+++ b/insurance-ams/src/app/(dashboard)/admin/page.tsx
@@ -1,21 +1,56 @@
+"use client";
+
 import CountChart from "@/Component/CountChart";
 import UserCard from "@/Component/UserCard";
 import ClientPipelineChart from "@/Component/ClientPipelineChart";
 import InsuredLineChart from "@/Component/InsuredLineChart";
 import EventCalendar from "@/Component/EventCalendar";
 import Accouncement from "@/Component/Accouncement";
+import React, { useEffect, useState } from "react";
+
+import {
+  getQuotesInProgress,
+  getOpenClaims,
+  getPendingToBindPolicies,
+  getLeads,
+  getExpiringPolicies60days,
+  getClaims,
+} from "@/actions/dashboard.action";
 
 const AdminPage = () => {
+  const [leads, setLeads] = useState<number>(0);
+  const [quotesInProgress, setQuotesInProgress] = useState<number>(0);
+  const [pendingToBindPolicies, setPendingToBindPolicies] = useState<number>(0);
+  const [expiringPolicies, setExpiringPolicies] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const leadsCount = await getLeads();
+      setLeads(leadsCount.length);
+
+      const quotesInProgressCount = await getQuotesInProgress();
+      setQuotesInProgress((quotesInProgressCount as any[]).length);
+
+      const pendingToBindPoliciesCount = await getPendingToBindPolicies();
+      setPendingToBindPolicies((pendingToBindPoliciesCount as any[]).length);
+
+      const expiringPoliciesCount = await getExpiringPolicies60days(60);
+      setExpiringPolicies((expiringPoliciesCount as any[]).length);
+    };
+
+    fetchData();
+  }, []);
+
   return (
     <div className="p-4 flex gap-4 flex-col md:flex-row">
       {/* LEFT */}
       <div className="w-full lg:w-2/3 flex flex-col gap-8">
         {/* UserCards */}
         <div className="flex gap-4 justify-between flex-wrap">
-          <UserCard type="Leads" amount={323} />
-          <UserCard type="Quoted" amount={99} />
-          <UserCard type="Pending" amount={3} />
-          <UserCard type="Renewals" amount={893} />
+          <UserCard type="Leads" amount={leads} />
+          <UserCard type="Quoted" amount={quotesInProgress} />
+          <UserCard type="Pending" amount={pendingToBindPolicies} />
+          <UserCard type="Renewals" amount={expiringPolicies} />
         </div>
         {/* Middle Charts */}
         <div className="flex gap-4 flex-col lg:flex-row">


### PR DESCRIPTION
The admin dashboard has API connected so usercards (top 4 boxes), policies circle chart, and pipeline all have data linked from database. The line chart is not connect since current clients do not go back further an one month. May edit line chart

# How to test:
1. go to http://localhost:3000/admin
2. See if numbers and values on dashboard are same as in database.
3. In terminal call script `npm run syntheticData` to add new data then refresh the page and the values should all increase. (because more data was added)

If no issues then PR can be approved.